### PR TITLE
Fix error if Color is indexed with a non-string

### DIFF
--- a/Color/color.lua
+++ b/Color/color.lua
@@ -57,9 +57,11 @@ local playerColors = {
     ['black']  = Color.new(0.25, 0.25, 0.25),
 }
 colorMt.__index = function(_, colorName)
-    colorName = colorName:lower()
-    if playerColors[colorName] then
-        return playerColors[colorName]:copy()
+    if type(colorName) == 'string' then
+        colorName = colorName:lower()
+        if playerColors[colorName] then
+            return playerColors[colorName]:copy()
+        end
     end
     return nil
 end

--- a/Color/colorTest.lua
+++ b/Color/colorTest.lua
@@ -111,9 +111,14 @@ local function test(Color, verbose)
     Color.Add('Turquoise', Color(0.1, 0.2, 0.3))
     testEq(Color.Turquoise, Color(0.1, 0.2, 0.3))
     testEq(Color.Nonexistent, nil)
+    testEq(Color[nil], nil)
 
     testEq(Color(0.1, 0.2, 0.3):lerp(Color(0.8, 0.8, 0.8), 0.5), Color(0.45, 0.5, 0.55))
-    
+
+    testEq(Color(0.1, 0.2, 0.3)[0], nil)
+    testEq(Color(0.1, 0.2, 0.3)[999], nil)
+    testEq(Color(0.1, 0.2, 0.3).foo, nil)
+
     print('Pass')
 end
 


### PR DESCRIPTION
At the moment non-string access on `Color` e.g.
```lua
Color[nil]
```
will raise an error.

Whilst the above example could reasonably be considered user error, index keys (i.e. _numbers_) are funnelled through when indexing a `Color` _instance_. So if you attempt to index a `Color` instance outside the range [1, 4], rather than getting `nil` back as you'd expect for non-existent keys on a `table`, instead an error is presently being raised.

# Reproduction

e.g. Entering the following in TTS' chat:

> /execute log(Color()[5])

Leads to:

> attempt to index a number value

where as you'd expect to see `nil` logged.