### PR TITLE
Fix outdated repo name in TTS tests require paths

### DIFF
--- a/Color/ttsColorTest.lua
+++ b/Color/ttsColorTest.lua
@@ -1,7 +1,7 @@
 -- for require'ing from Atom to be ran in TTS
 
-local test = require('tts_lua_classes/Color/colorTest')
-local Color = require('tts_lua_classes/Color/color')
+local test = require('Tabletop-Simulator-Lua-Classes/Color/colorTest')
+local Color = require('Tabletop-Simulator-Lua-Classes/Color/color')
 
 local _old = onLoad
 function onLoad()

--- a/Vector/ttsVectorTest.lua
+++ b/Vector/ttsVectorTest.lua
@@ -1,7 +1,7 @@
 -- for require'ing from Atom to be ran in TTS
 
-local test = require('tts_lua_classes/Vector/vectorTest')
-local Vector = require('tts_lua_classes/Vector/vector')
+local test = require('Tabletop-Simulator-Lua-Classes/Vector/vectorTest')
+local Vector = require('Tabletop-Simulator-Lua-Classes/Vector/vector')
 
 local _old = onLoad
 function onLoad()


### PR DESCRIPTION
Changed to current so tests can be ran from TTS with a single #include with the repo cloned at project path.