### PR TITLE
Fixed Color.FromHex when using alpha under Moonsharp

### DIFF
--- a/Color/color.lua
+++ b/Color/color.lua
@@ -84,16 +84,21 @@ end
 
 function Color.fromHex(hexColor)
     local rStr, gStr, bStr, aStr = hexColor:match('^#?(%x%x)(%x%x)(%x%x)(%x?%x?)$')
-    
-    assert(rStr and gStr and bStr and (aStr:len() == 0 or aStr:len() == 2), tostring(hexColor) .. ' is not a valid color hex string')
+    local aStrLen = aStr:len()    
+
+    assert(rStr and gStr and bStr and (aStrLen == 0 or aStrLen == 2), tostring(hexColor) .. ' is not a valid color hex string')
+
+    -- Moonsharp non-standard behavior: errors on tonumber('', base)
+    local a = aStrLen > 0 and tonumber(aStr, 16) or 255
 
     return Color(
         tonumber(rStr, 16)/255, 
         tonumber(gStr, 16)/255, 
         tonumber(bStr, 16)/255,
-        (tonumber(aStr, 16) or 255)/255
+        a/255
     )
 end
+
 
 function Color:get()
     return self.r, self.g, self.b, self.a

--- a/Color/colorTest.lua
+++ b/Color/colorTest.lua
@@ -114,6 +114,9 @@ local function test(Color, verbose)
 
     testEq(Color(0.1, 0.2, 0.3):lerp(Color(0.8, 0.8, 0.8), 0.5), Color(0.45, 0.5, 0.55))
     
+    testEq(Color.fromHex('#f7e7ce'), Color(0xf7 / 255, 0xe7 / 255, 0xce / 255))
+    testEq(Color.fromHex('#f7e7ceab'), Color(0xf7 / 255, 0xe7 / 255, 0xce / 255, 0xab / 255))
+    
     print('Pass')
 end
 


### PR DESCRIPTION
Apparently ``tonumber(numStr, base)`` errors if ``numStr`` is an empty string and ``base`` is a number. Thanks Moonsharp.